### PR TITLE
Update Certificates in docker image

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:latest
+RUN apk update && apk add --no-cache ca-certificates
 COPY mfaws /
 ENTRYPOINT [ "/mfaws" ]


### PR DESCRIPTION
When building the docker image, we can make sure we have all
certificates that are up to date with the CA server.

This enables the following command: 

```bash
docker run -it -v ~/.aws/:/root/.aws pbar1/mfaws:latest --force -t $(get-token-script)
```

from responding with 

> 2001/01/01 00:00:00 RequestError: send request failed
caused by: Post https://sts.amazonaws.com/: x509: certificate signed by unknown authority

To being a successful after having built the docker image. 

This does probably require some kind of job to rebuild the docker image periodically. 

The alternative is to actually create a docker file manually: 

```Dockerfile
FROM pbar1/mfaws:latest
RUN apk update && apk add ca-certificates 
```

But it's nice when downloading the docker image, to have something fully functional out of the box. 