### PR TITLE
Update Goreleaser and build for more architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,20 +15,25 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+
+universal_binaries:
+  - ids:
+      - mfaws
+    replace: false
 
 archives:
   -
     format: binary
-    replacements:
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
-    files:
-      - none*
-
+    name_template: |
+      mfaws_
+      {{- .Version}}_
+      {{- if eq .Os "darwin" }}macOS
+      {{- else if eq .Os "linux" }}Linux
+      {{- else if eq .Os "windows" }}Windows{{ end }}_
+      {{- .Arch -}}
 release:
   prerelease: auto
 
@@ -49,7 +54,7 @@ dockers:
   -
     goos: linux
     goarch: amd64
-    binaries:
+    ids:
     - mfaws
     dockerfile: build/package/Dockerfile
     image_templates:


### PR DESCRIPTION
This allows for compatibility with new version of goreleaser. 

It also adds universal binaries and support for more architectures


I would also propose releasing a `brew` formula, by adding something like: 

```yaml
brews:
  - name: mfaws
    folder: Formula
    description: Handling AWS CLI with Multi Factor Authentication
    homepage: https://github.com/pbar1/mfaws
    repository:
      owner: frankywahl
      name: homebrew-tap
    test: |
      assert_match "{{ .Version }}, commit {{ .ShortCommit }}, built at {{ .Date }}", shell_output("#{bin}/mfaws version")
    # ...
```

It would make it an easy way to have many users install the CLI quickly. 

For the time being - I've done my own [here](https://github.com/frankywahl/homebrew-tap/blob/main/Formula/mfaws.rb) but having something automated and up to date with all architectures would be nice.